### PR TITLE
Open wallet modal when user clicks 'Place Bid' if no wallet is connected

### DIFF
--- a/src/components/Auction/Bid.tsx
+++ b/src/components/Auction/Bid.tsx
@@ -38,7 +38,9 @@ export default function Bid({ nounId, nextMinBid }: BidProps) {
     });
   }, [nextMinBidFormatted]);
 
-  async function onSubmit(formData: FormData) {
+  async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
     const parsedBidAmount = parseEther(formData.get("bidAmount") as string);
     createBid(nounId, parsedBidAmount);
   }
@@ -53,7 +55,7 @@ export default function Bid({ nounId, nextMinBid }: BidProps) {
 
   return (
     <div className="flex w-full flex-col gap-1">
-      <form action={onSubmit} className="flex flex-col gap-2 md:flex-row md:gap-4">
+      <form onSubmit={onSubmit} className="flex flex-col gap-2 md:flex-row md:gap-4">
         <div className="relative h-full w-full md:w-[260px]">
           <Input
             placeholder={`Ξ ${nextMinBidFormatted} or more`}


### PR DESCRIPTION
Haven't tested this because I vibe coded it w/ codex and don't have the app running locally 😅 

Please test, and if you have and if you have any feedback or requests, lmk and I will relay to Codex 🫡 

Context: We're hoping to embed nouns.com on the homepage on nounspace, but want to offset the embed so we can avoid double navs. This is the missing piece for us to be able to do this cleanly.

Plus will be a nice UX improvement :)

Cheers bros!